### PR TITLE
fix: Add trailing 0s to float fields

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fixed-width-parser",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fixed-width-parser",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "A fixed width data parser",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/FixedWidthParser.ts
+++ b/src/FixedWidthParser.ts
@@ -84,10 +84,20 @@ export class FixedWidthParser<T extends JsonObject = JsonObject> {
           switch (config.type) {
             case 'float': {
               const numAsStr: string = record[config.name].toString();
-              const strippedDecimals = numAsStr.slice(
+              let strippedDecimals = numAsStr.slice(
                 0,
                 numAsStr.indexOf('.') + (config.decimalCount ?? 2) + 1,
               );
+              // Add expected decimal places
+              const currentDecimals = strippedDecimals.slice(strippedDecimals.indexOf('.') + 1)
+                .length;
+              if (config.decimalCount > currentDecimals) {
+                const decimalsNeeded = config.decimalCount - currentDecimals;
+                strippedDecimals = strippedDecimals.padEnd(
+                  strippedDecimals.length + decimalsNeeded,
+                  '0',
+                );
+              }
               value =
                 config.insertDecimal ?? true
                   ? strippedDecimals

--- a/test/unparse.spec.ts
+++ b/test/unparse.spec.ts
@@ -319,8 +319,94 @@ describe('FixedWidthParser.unparse', () => {
     ]);
 
     expect(actual).toStrictEqual(
-      '604d7d16-36be-47fd-ab70-e9c93b34c91f                      12345.1234',
+      '604d7d16-36be-47fd-ab70-e9c93b34c91f                     12345.12340',
     );
+  });
+
+  it('should respect leading and trailing 0s', () => {
+    const fixedWidthParser = new FixedWidthParser([
+      {
+        name: 'accountId',
+        start: 0,
+        width: 36,
+      },
+      {
+        padChar: '0',
+        padPosition: 'start',
+        type: 'float',
+        decimalCount: 3,
+        insertDecimal: false,
+        name: 'balance',
+        start: 36,
+        width: 5,
+      },
+    ]);
+
+    const actual = fixedWidthParser.unparse([
+      {
+        accountId: '604d7d16-36be-47fd-ab70-e9c93b34c91f',
+        balance: 5.5,
+      },
+    ]);
+
+    expect(actual).toStrictEqual('604d7d16-36be-47fd-ab70-e9c93b34c91f05500');
+  });
+
+  it('should not add extra trailing 0s', () => {
+    const fixedWidthParser = new FixedWidthParser([
+      {
+        name: 'accountId',
+        start: 0,
+        width: 36,
+      },
+      {
+        padChar: '0',
+        padPosition: 'start',
+        type: 'float',
+        decimalCount: 3,
+        insertDecimal: false,
+        name: 'balance',
+        start: 36,
+        width: 5,
+      },
+    ]);
+
+    const actual = fixedWidthParser.unparse([
+      {
+        accountId: '604d7d16-36be-47fd-ab70-e9c93b34c91f',
+        balance: 5.555,
+      },
+    ]);
+
+    expect(actual).toStrictEqual('604d7d16-36be-47fd-ab70-e9c93b34c91f05555');
+  });
+
+  it('should default to a decimalCount of 2', () => {
+    const fixedWidthParser = new FixedWidthParser([
+      {
+        name: 'accountId',
+        start: 0,
+        width: 36,
+      },
+      {
+        padChar: '0',
+        padPosition: 'start',
+        type: 'float',
+        insertDecimal: false,
+        name: 'balance',
+        start: 36,
+        width: 5,
+      },
+    ]);
+
+    const actual = fixedWidthParser.unparse([
+      {
+        accountId: '604d7d16-36be-47fd-ab70-e9c93b34c91f',
+        balance: 5.555,
+      },
+    ]);
+
+    expect(actual).toStrictEqual('604d7d16-36be-47fd-ab70-e9c93b34c91f00555');
   });
 
   it('should skip inserting decimal depending on config', () => {


### PR DESCRIPTION
JSON numbers omit trailing zeros by default, which is fine when parsing, but not unparsing. When the floating point value is determined by the specified decimal count instead of where the decimal point is located, adding leading zeros but not trailing zeros in the final string produces an incorrect value. For example when given a field and configuration:

```ts
const field = {
  balance: 5.5
}

const config = {
  padChar: '0',
  padPosition: 'start',
  type: 'float',
  insertDecimal: false,
  name: 'balance',
  start: 0,
  width: 5,
}
```

The resulting string is `"00055"` which, with the given configuration, becomes the value 0.055 instead of the original 5.5. Adding trailing zeros to pad out the specified decimal count returns the string `"05500"` which preserves the original value.
