### PR TITLE
fix: float unparsing to handle missing decimal point

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fixed-width-parser",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fixed-width-parser",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "A fixed width data parser",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/FixedWidthParser.ts
+++ b/src/FixedWidthParser.ts
@@ -84,13 +84,21 @@ export class FixedWidthParser<T extends JsonObject = JsonObject> {
           switch (config.type) {
             case 'float': {
               const numAsStr: string = record[config.name].toString();
+              // If the value not longer contains a decimal point
+              // (123.00 -> 123) assume the decimal point should be at the end.
+              const decimalIndex =
+                numAsStr.indexOf('.') > -1 ? numAsStr.indexOf('.') : numAsStr.length;
+
               let strippedDecimals = numAsStr.slice(
                 0,
-                numAsStr.indexOf('.') + (config.decimalCount ?? 2) + 1,
+                decimalIndex + (config.decimalCount ?? 2) + 1,
               );
               // Add expected decimal places
-              const currentDecimals = strippedDecimals.slice(strippedDecimals.indexOf('.') + 1)
-                .length;
+              const currentDecimals =
+                strippedDecimals.indexOf('.') > -1
+                  ? strippedDecimals.slice(strippedDecimals.indexOf('.') + 1).length
+                  : 0;
+
               if (config.decimalCount > currentDecimals) {
                 const decimalsNeeded = config.decimalCount - currentDecimals;
                 strippedDecimals = strippedDecimals.padEnd(
@@ -98,6 +106,7 @@ export class FixedWidthParser<T extends JsonObject = JsonObject> {
                   '0',
                 );
               }
+
               value =
                 config.insertDecimal ?? true
                   ? strippedDecimals

--- a/test/unparse.spec.ts
+++ b/test/unparse.spec.ts
@@ -409,6 +409,35 @@ describe('FixedWidthParser.unparse', () => {
     expect(actual).toStrictEqual('604d7d16-36be-47fd-ab70-e9c93b34c91f00555');
   });
 
+  it('should respect decimalCount even when there is no decimal', () => {
+    const fixedWidthParser = new FixedWidthParser([
+      {
+        name: 'accountId',
+        start: 0,
+        width: 36,
+      },
+      {
+        type: 'float',
+        name: 'balance',
+        start: 36,
+        width: 32,
+        decimalCount: 4,
+        insertDecimal: false,
+      },
+    ]);
+
+    const actual = fixedWidthParser.unparse([
+      {
+        accountId: '604d7d16-36be-47fd-ab70-e9c93b34c91f',
+        balance: 12345,
+      },
+    ]);
+
+    expect(actual).toStrictEqual(
+      '604d7d16-36be-47fd-ab70-e9c93b34c91f                       123450000',
+    );
+  });
+
   it('should skip inserting decimal depending on config', () => {
     const fixedWidthParser = new FixedWidthParser([
       {


### PR DESCRIPTION
Because the parser expects floating point values to include a decimal point, but JSON omits the decimal point and decimal places if they are 0, i.e. 1234.00, floating point values without a decimal point were incorrectly shortened. For example, the value 1234 when parsed with two decimal places and a field width of 8, would be cut to 12, and rendered as `00000012`.

This fix allows the parser to default to the last position in the string +1, where the decimal would normally appear, in the event it is not included in the value.