### PR TITLE
feat: Add support for a parse config level truncate option

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,18 +117,6 @@ const result = fixedWidthParser.unparse(input);
 33        jeff
 ```
 
-### Unparse Options
-
-```typescript
-interface IUnparseOptions {
-  // Allows truncating values that are too long instead of throwing.
-  // This value can be overridden by the 'truncate' option in a parse config for
-  // each individual segment of text.
-  // default: false
-  truncate: boolean;
-}
-```
-
 ## Config
 
 When initializing a new instance of the `FixedWidthParser` class, you must provide
@@ -153,7 +141,7 @@ interface IBaseParseConfig {
   padString?: string;
   // value to use when unparsing if field in input is undefined
   default?: string | number;
-  // default false; overrides the IUnparseOptions
+  // overrides FixedWidthParser.defaults.truncate
   truncate?: boolean;
 }
 ```
@@ -254,9 +242,28 @@ interface IParseConfigValidationError {
 }
 ```
 
+## Parser Options
+
+```typescript
+interface IFixedWidthParserOptions {
+  // Allows truncating values that are too long instead of throwing.
+  //
+  // This value can be overridden by the 'truncate' option in individual parse configs.
+  // default: true
+  truncate?: boolean;
+  // If provided, enables an additional validation of the provided parse config
+  // map. If sum of all `width` values in the parse config map do not match this
+  // value, then the an error is thrown.
+  expectedFullWidth?: number;
+}
+```
+
 ## Thanks
 
 A huge thanks to @SteveyPugs for his work on `fixy` which served as inspiration
 for `fixed-width-parser`! `fixed-width-parser` started out as a fork of `fixy` and
 evolved into its own library when I got carried away and implemented a new high-level
 API.
+
+Another huge thanks to @wk-davis for her help with concept discussions and ongoing
+development help!

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ const input = [
     age: 33,
     name: 'jeff',
   },
-]
+];
 
 const result = fixedWidthParser.unparse(input);
 ```
@@ -121,7 +121,9 @@ const result = fixedWidthParser.unparse(input);
 
 ```typescript
 interface IUnparseOptions {
-  // Allows truncating values that are too long instead of throwing
+  // Allows truncating values that are too long instead of throwing.
+  // This value can be overridden by the 'truncate' option in a parse config for
+  // each individual segment of text.
   // default: false
   truncate: boolean;
 }
@@ -151,12 +153,14 @@ interface IBaseParseConfig {
   padString?: string;
   // value to use when unparsing if field in input is undefined
   default?: string | number;
+  // default false; overrides the IUnparseOptions
+  truncate?: boolean;
 }
 ```
 
 An explicit `type` property can be provided in each parse config to specify what
 data types to use for values parsed from strings. Several of these data types require
-additional properties to be provided to fully define how parse/unparse values. 
+additional properties to be provided to fully define how parse/unparse values.
 
 ```typescript
 // Default config type

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fixed-width-parser",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fixed-width-parser",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fixed-width-parser",
-  "version": "1.2.2",
+  "version": "1.3.0",
   "description": "A fixed width data parser",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fixed-width-parser",
-  "version": "1.3.0",
+  "version": "2.0.0",
   "description": "A fixed width data parser",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/FixedWidthParser.ts
+++ b/src/FixedWidthParser.ts
@@ -145,7 +145,10 @@ export class FixedWidthParser<T extends JsonObject = JsonObject> {
 
         // Handle truncate or error
         if (value.length > config.width) {
-          if (!options?.truncate) {
+          // Prioritize config-level option over parser-level options
+          const shouldTruncate = config!.truncate ?? options!.truncate;
+
+          if (!shouldTruncate) {
             throw new Error(`Unable to parse value '${value}' into width of '${config.width}'!`);
           }
 

--- a/src/FixedWidthParser.ts
+++ b/src/FixedWidthParser.ts
@@ -3,21 +3,19 @@ import { JsonObject } from './interfaces/json';
 import { IParseConfigValidationError } from './interfaces/IParseConfigValidationError';
 import { splice } from './splice';
 import { parse as parseToDate, isValid as isValidDate, format as formatDate } from 'date-fns';
-import { IUnparseOptions } from './interfaces/IUnparseOptions';
 import { trimString } from './trimString';
 import { IParseOptions } from './interfaces/IParseOptions';
 import { handleFalsyFallback } from './handleFalsyFallback';
-
-interface IFixedWidthParserOptions {
-  /**
-   * Will throw an error if config widths do not add up to this value.
-   */
-  expectedFullWidth?: number;
-}
+import { IFixedWidthParserOptions } from './interfaces/IFixedWidthParserOptions';
+import { IDefaults } from './interfaces/IDefaults';
 
 export class FixedWidthParser<T extends JsonObject = JsonObject> {
   private parseConfigMap: ParseConfig[];
   private fullWidth: number;
+  /**
+   * Default values of parameters used during parse and unparse.
+   */
+  public defaults: IDefaults;
 
   /**
    * @param parseConfigMap Array of parse configs
@@ -28,7 +26,9 @@ export class FixedWidthParser<T extends JsonObject = JsonObject> {
       throw new Error(`Invalid parse config! Parse config is empty!`);
     }
 
-    this.parseConfigMap = parseConfigMap.sort((a, b) => a.start - b.start).map(this.applyDefaults);
+    this.parseConfigMap = parseConfigMap
+      .sort((a, b) => a.start - b.start)
+      .map(this.applyDefaultType);
 
     const validationErrors = this.parseConfigMap
       .map(this.validateParseConfigs)
@@ -45,6 +45,10 @@ export class FixedWidthParser<T extends JsonObject = JsonObject> {
         `Calculated full width (${this.fullWidth}) does not match asserted full width (${options.expectedFullWidth})!`,
       );
     }
+
+    this.defaults = {
+      truncate: options?.truncate ?? true,
+    };
   }
 
   public parse(input: string, options?: Partial<IParseOptions>): T[] {
@@ -66,7 +70,7 @@ export class FixedWidthParser<T extends JsonObject = JsonObject> {
     return lines.map((line) => this.parseLine(line, options));
   }
 
-  public unparse(input: unknown[], options?: Partial<IUnparseOptions>): string {
+  public unparse(input: unknown[]): string {
     if (!input || input.length <= 0) {
       throw new Error('Invalid input! Input is empty!');
     }
@@ -155,9 +159,7 @@ export class FixedWidthParser<T extends JsonObject = JsonObject> {
         // Handle truncate or error
         if (value.length > config.width) {
           // Prioritize config-level option over parser-level options
-          const shouldTruncate = config!.truncate ?? options!.truncate;
-
-          if (!shouldTruncate) {
+          if (!(config.truncate ?? this.defaults.truncate)) {
             throw new Error(`Unable to parse value '${value}' into width of '${config.width}'!`);
           }
 
@@ -273,7 +275,7 @@ export class FixedWidthParser<T extends JsonObject = JsonObject> {
     }
   };
 
-  private applyDefaults = (parseConfig: ParseConfigInput): ParseConfig => {
+  private applyDefaultType = (parseConfig: ParseConfigInput): ParseConfig => {
     if (!parseConfig.type) {
       parseConfig.type = 'string';
     }

--- a/src/interfaces/IDefaults.ts
+++ b/src/interfaces/IDefaults.ts
@@ -1,0 +1,6 @@
+export interface IDefaults {
+  /**
+   * Default behavior used if `truncate` is not set on a ParseConfig.
+   */
+  truncate: boolean;
+}

--- a/src/interfaces/IFixedWidthParserOptions.ts
+++ b/src/interfaces/IFixedWidthParserOptions.ts
@@ -1,0 +1,10 @@
+export interface IFixedWidthParserOptions {
+  /**
+   * Will throw an error if config widths do not add up to this value.
+   */
+  expectedFullWidth?: number;
+  /**
+   * Default behavior used if `truncate` is not set on a ParseConfig.
+   */
+  truncate?: boolean;
+}

--- a/src/interfaces/IUnparseOptions.ts
+++ b/src/interfaces/IUnparseOptions.ts
@@ -1,3 +1,0 @@
-export interface IUnparseOptions {
-  truncate: boolean;
-}

--- a/src/interfaces/ParseConfig.ts
+++ b/src/interfaces/ParseConfig.ts
@@ -17,6 +17,7 @@ interface IBaseParseConfig {
   padPosition?: 'start' | 'end';
   padChar?: string;
   default?: string | number;
+  truncate?: boolean;
 }
 
 export interface ISkipParseConfig extends IBaseParseConfig {

--- a/test/unparse.spec.ts
+++ b/test/unparse.spec.ts
@@ -174,29 +174,45 @@ describe('FixedWidthParser.unparse', () => {
     expect(actual).toStrictEqual('00000001111what');
   });
 
-  it('should throw error if value cannot fit in defined width', () => {
+  // Truncation settings
+  // => errors
+  test.each([
+    [false, undefined],
+    [undefined, false],
+    [false, true],
+    [undefined, undefined],
+    [false, false],
+  ])('should throw an error if value cannot fit in defined width', (fieldLevel, parserLevel) => {
     const fixedWidthParser = new FixedWidthParser([
       {
         name: 'Name',
         start: 0,
         width: 7,
+        truncate: fieldLevel,
       },
     ]);
 
     try {
-      fixedWidthParser.unparse([{ Name: 'Alexander' }]);
+      fixedWidthParser.unparse([{ Name: 'Alexander' }], { truncate: parserLevel });
       fail('should have thrown error');
     } catch (err) {
       expect(err.message).toBe("Unable to parse value 'Alexander' into width of '7'!");
     }
   });
 
-  it('should optionally truncate values that are too long', () => {
+  // => truncation
+  test.each([
+    [true, undefined],
+    [true, false],
+    [undefined, true],
+    [true, true],
+  ])('should truncate values that are too long', (fieldLevel, parserLevel) => {
     const fixedWidthParser = new FixedWidthParser([
       {
         name: 'Name',
         start: 0,
         width: 7,
+        truncate: fieldLevel,
       },
     ]);
 
@@ -206,9 +222,7 @@ describe('FixedWidthParser.unparse', () => {
           Name: 'Alexander',
         },
       ],
-      {
-        truncate: true,
-      },
+      { truncate: parserLevel },
     );
 
     expect(actual).toStrictEqual('Alexand');


### PR DESCRIPTION
For times when setting the truncation option on the parser isn't granular enough, this PR allows truncation to be defined in the parse configuration for setting truncation per field.