### PR TITLE
feat: Throw an error if an int is not given during unparse for int types

### DIFF
--- a/src/FixedWidthParser.ts
+++ b/src/FixedWidthParser.ts
@@ -127,6 +127,11 @@ export class FixedWidthParser<T extends JsonObject = JsonObject> {
             }
 
             case 'int':
+              // Don't assume that the value is an int.
+              const truncatedValue: number = parseInt(record[config.name].toString());
+              if(truncatedValue != record[config.name]){
+                throw new Error('Int value was not an int');
+              }
               value = record[config.name].toString(config.radix ?? 10);
               break;
 
@@ -171,11 +176,11 @@ export class FixedWidthParser<T extends JsonObject = JsonObject> {
             throw new Error(`Unable to parse value '${value}' into width of '${config.width}'!`);
           }
 
-          console.warn(
-            `Truncating value '${value}' to '${value.slice(0, config.width)}' to fit in '${
-              config.name
-            }' width of '${config.width}'.`,
-          );
+          // console.warn(
+          //   `Truncating value '${value}' to '${value.slice(0, config.width)}' to fit in '${
+          //     config.name
+          //   }' width of '${config.width}'.`,
+          // );
 
           value = value.slice(0, config.width);
         }
@@ -256,7 +261,7 @@ export class FixedWidthParser<T extends JsonObject = JsonObject> {
           return false;
         }
 
-        console.warn(`Failed to parse to boolean value. Falling back to ${options.falsyFallback}.`);
+        //console.warn(`Failed to parse to boolean value. Falling back to ${options.falsyFallback}.`);
         return handleFalsyFallback(false, options.falsyFallback);
       }
 
@@ -267,7 +272,7 @@ export class FixedWidthParser<T extends JsonObject = JsonObject> {
         }
 
         const failValue = handleFalsyFallback(null, options.falsyFallback);
-        console.warn(`Failed to parse to date value. Falling back to ${failValue}.`);
+        //console.warn(`Failed to parse to date value. Falling back to ${failValue}.`);
         return failValue;
       }
 

--- a/test/unparse.spec.ts
+++ b/test/unparse.spec.ts
@@ -617,4 +617,34 @@ describe('FixedWidthParser.unparse', () => {
 
     expect(actual).toStrictEqual('a');
   });
+
+  it('should throw an error if an int value is not an int', () => {
+    const fixedWidthParser = new FixedWidthParser([
+      {
+        name: 'Age',
+        start: 0,
+        width: 7,
+        type: 'int',
+      },
+      {
+        name: 'Initial',
+        start: 7,
+        width: 4,
+      },
+    ]);
+    try {
+      fixedWidthParser.unparse([
+        {
+          Age: 3.10,
+          Initial: 'SJP',
+        },
+        {
+          Age: 20,
+          Initial: 'CCS',
+        },
+      ]);
+    } catch (error) {
+      expect(error.message).toBe("Int value was not an int")
+    }
+  });
 });


### PR DESCRIPTION
If we are unparsing, there is not a check to see if the end users are actually passing the correct type value. The code assumes that the information is correct, and will work with the value as is instead of making sure that the value is correct. 

For this update, I am checking to see if the `int` type has an `int` type as the value, if it does, it works as normal, but if not, we throw an error. 

Also commented out the console.warn() values since those are clogging debug files. 

Updated the unit test as well to make sure the new code works as intended. 