### PR TITLE
feat: floor on 'int' types during unparse

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,15 @@ interface IIntegerParseConfig {
   // integer between 2 and 36 that represents the radix of the string
   // default: 10
   radix?: number;
+  // When parsing and unparsing, there may be an error that the value given is not
+  // an integer. This is a way of the parser to work around this issue. Give an option here
+  // to have the parser do the following when encountering a non-int as an int-type
+  // ceil: performs Math.ceil() on the data
+  // floor: performs Math.floor() on the data
+  // round: performs Math.round() on the data
+  // error: Will throw an error if the data is not an int
+  // default: floor
+  mend?: 'ceil' | 'floor' | 'round' | 'error'
 }
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "fixed-width-parser",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fixed-width-parser",
-  "version": "2.2.0",
+  "version": "2.3.0",
   "description": "A fixed width data parser",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/FixedWidthParser.ts
+++ b/src/FixedWidthParser.ts
@@ -132,6 +132,11 @@ export class FixedWidthParser<T extends JsonObject = JsonObject> {
             }
 
             case 'int':
+              // Don't assume that the value is an int.
+              const truncatedValue: number = parseInt(record[config.name].toString());
+              if(truncatedValue != record[config.name]){
+                throw new Error('Int value was not an int');
+              }
               value = record[config.name].toString(config.radix ?? 10);
               break;
 

--- a/src/FixedWidthParser.ts
+++ b/src/FixedWidthParser.ts
@@ -133,11 +133,7 @@ export class FixedWidthParser<T extends JsonObject = JsonObject> {
 
             case 'int':
               // Don't assume that the value is an int.
-              const truncatedValue: number = parseInt(record[config.name].toString());
-              if(truncatedValue != record[config.name]){
-                throw new Error('Int value was not an int');
-              }
-              value = record[config.name].toString(config.radix ?? 10);
+              value = Math.floor(record[config.name]).toString(config.radix ?? 10);
               break;
 
             case 'string':

--- a/src/FixedWidthParser.ts
+++ b/src/FixedWidthParser.ts
@@ -133,7 +133,20 @@ export class FixedWidthParser<T extends JsonObject = JsonObject> {
 
             case 'int':
               // Don't assume that the value is an int.
-              value = Math.floor(record[config.name]).toString(config.radix ?? 10);
+              switch (config.mend) {
+                case 'ceil':
+                  value = Math.ceil(record[config.name]).toString(10);
+                  break;
+                case 'round':
+                  value = Math.round(record[config.name]).toString(10);
+                  break;
+                case 'error':
+                  throw new Error(`Expected parsed value for '${config.name}' to be an integer`);
+                case 'floor':
+                default:
+                  value = Math.floor(record[config.name]).toString(config.radix ?? 10);
+                  break;
+              }
               break;
 
             case 'string':
@@ -235,10 +248,26 @@ export class FixedWidthParser<T extends JsonObject = JsonObject> {
     // Parse remaining string
     switch (config.type) {
       case 'int': {
-        return handleFalsyFallback(
-          parseInt(trimmedString, config.radix ?? 10),
-          options.falsyFallback,
-        );
+        let value: number;
+        if (!config.radix || config.radix === 10) {
+          switch (config.mend) {
+            case 'ceil':
+              value = Math.ceil(parseFloat(trimmedString));
+              break;
+            case 'round':
+              value = Math.round(parseFloat(trimmedString));
+              break;
+            case 'error':
+              throw new Error(`Expected parsed value for '${config.name}' to be an integer`);
+            case 'floor':
+            default:
+              value = parseInt(trimmedString);
+              break;
+          }
+        } else {
+          value = parseInt(trimmedString, config.radix);
+        }
+        return handleFalsyFallback(value, options.falsyFallback);
       }
 
       case 'float': {
@@ -340,6 +369,18 @@ export class FixedWidthParser<T extends JsonObject = JsonObject> {
         if (parseConfig.type === 'float' && parseConfig.decimalCount > parseConfig.width) {
           errorResponse.errors.push(
             `Cannot have '${parseConfig.decimalCount}' decimals when field is only '${parseConfig.width}' char wide.`,
+          );
+        }
+
+        if (
+          parseConfig.type === 'int' &&
+          parseConfig.radix &&
+          parseConfig.radix !== 10 &&
+          parseConfig.mend &&
+          parseConfig.mend !== 'error'
+        ) {
+          errorResponse.errors.push(
+            `Cannot have a radix of '${parseConfig.radix} with any sort of rounding solution.`,
           );
         }
         break;

--- a/src/interfaces/ParseConfig.ts
+++ b/src/interfaces/ParseConfig.ts
@@ -33,6 +33,7 @@ export interface IIntegerParseConfig extends IBaseParseConfig {
   type: 'int';
   name: string;
   radix?: number;
+  mend?: 'floor' | 'ceil' | 'round' | 'error';
 }
 
 export interface IFloatParseConfig extends IBaseParseConfig {

--- a/test/constructor.spec.ts
+++ b/test/constructor.spec.ts
@@ -109,6 +109,26 @@ describe('constructor', () => {
     }
   });
 
+  it('should throw an error there is a int value with a mend type not equal to error and a radix not equal to 10', () => {
+    try {
+      new FixedWidthParser([
+        {
+          name: 'Test',
+          width: 3,
+          start: 0,
+          type: 'int',
+          mend: 'ceil',
+          radix: 8,
+        },
+      ]);
+      fail('should have thrown an error');
+    } catch (err) {
+      expect(err.length).toBe(1);
+      expect(err[0].index).toBe(0);
+      expect(err[0].errors).toHaveLength(1);
+    }
+  });
+
   it('should throw an error if bool type not provided a trueValue', () => {
     try {
       new FixedWidthParser([

--- a/test/parse.spec.ts
+++ b/test/parse.spec.ts
@@ -514,6 +514,99 @@ describe('FixedWidthParser.parse', () => {
     ]);
   });
 
+  it('should respect mending type of ceil', () => {
+    const fixedWidthParser = new FixedWidthParser([
+      {
+        type: 'int',
+        name: 'a',
+        width: 3,
+        start: 0,
+        mend: 'ceil',
+      },
+    ]);
+
+    const actual = fixedWidthParser.parse('1.6');
+
+    expect(actual).toStrictEqual([
+      {
+        a: 2,
+      },
+    ]);
+  });
+
+  it('should respect mending type of round', () => {
+    const fixedWidthParser = new FixedWidthParser([
+      {
+        type: 'int',
+        name: 'a',
+        width: 3,
+        start: 0,
+        mend: 'round',
+      },
+    ]);
+
+    const actual = fixedWidthParser.parse('1.4');
+
+    expect(actual).toStrictEqual([
+      {
+        a: 1,
+      },
+    ]);
+  });
+
+  it('should respect multiple mending types', () => {
+    const fixedWidthParser = new FixedWidthParser([
+      {
+        type: 'int',
+        name: 'a',
+        width: 3,
+        start: 0,
+      },
+      {
+        type: 'int',
+        name: 'b',
+        width: 3,
+        start: 3,
+        mend: 'floor',
+      },
+      {
+        type: 'int',
+        name: 'c',
+        width: 3,
+        start: 6,
+        mend: 'round',
+      },
+    ]);
+
+    const actual = fixedWidthParser.parse('1.41.41.4');
+
+    expect(actual).toStrictEqual([
+      {
+        a: 1,
+        b: 1,
+        c: 1,
+      },
+    ]);
+  });
+
+  it('should respect mending type of error', () => {
+    const fixedWidthParser = new FixedWidthParser([
+      {
+        type: 'int',
+        name: 'a',
+        width: 3,
+        start: 0,
+        mend: 'error',
+      },
+    ]);
+
+    try {
+      fixedWidthParser.parse('1.1');
+    } catch (error) {
+      expect(error.message).toBeDefined();
+    }
+  });
+
   describe('options', () => {
     describe('falsyFallback', () => {
       describe('falsyFallback = passthrough', () => {

--- a/test/unparse.spec.ts
+++ b/test/unparse.spec.ts
@@ -618,7 +618,7 @@ describe('FixedWidthParser.unparse', () => {
     expect(actual).toStrictEqual('a');
   });
 
-  it('should throw an error if an int value is not an int', () => {
+  it('should floor an int type when not given an int', () => {
     const fixedWidthParser = new FixedWidthParser([
       {
         name: 'Age',
@@ -632,19 +632,16 @@ describe('FixedWidthParser.unparse', () => {
         width: 4,
       },
     ]);
-    try {
-      fixedWidthParser.unparse([
-        {
-          Age: 3.10,
-          Initial: 'SJP',
-        },
-        {
-          Age: 20,
-          Initial: 'CCS',
-        },
-      ]);
-    } catch (error) {
-      expect(error.message).toBe("Int value was not an int")
-    }
+    const actual = fixedWidthParser.unparse([
+      {
+        Age: 3.1,
+        Initial: 'SJP',
+      },
+      {
+        Age: 20,
+        Initial: 'CCS',
+      },
+    ]);
+    expect(actual).toBe('      3 SJP\n     20 CCS');
   });
 });

--- a/test/unparse.spec.ts
+++ b/test/unparse.spec.ts
@@ -618,7 +618,7 @@ describe('FixedWidthParser.unparse', () => {
     expect(actual).toStrictEqual('a');
   });
 
-  it('should floor an int type when not given an int', () => {
+  it('should floor an int type when not given a mending method', () => {
     const fixedWidthParser = new FixedWidthParser([
       {
         name: 'Age',
@@ -643,5 +643,101 @@ describe('FixedWidthParser.unparse', () => {
       },
     ]);
     expect(actual).toBe('      3 SJP\n     20 CCS');
+  });
+
+  it('should ceil an int type when given a mend of ceil', () => {
+    const fixedWidthParser = new FixedWidthParser([
+      {
+        name: 'Money',
+        start: 0,
+        width: 7,
+        type: 'int',
+        mend: 'ceil',
+        radix: 10,
+      },
+    ]);
+    const actual = fixedWidthParser.unparse([
+      {
+        Money: 312.45,
+      },
+    ]);
+    expect(actual).toBe('    313');
+  });
+
+  it('should round an int type when given round as a mending type', () => {
+    const fixedWidthParser = new FixedWidthParser([
+      {
+        name: 'Money',
+        start: 0,
+        width: 7,
+        type: 'int',
+        mend: 'round',
+        radix: 10,
+      },
+    ]);
+    const actual = fixedWidthParser.unparse([
+      {
+        Money: 312.45,
+      },
+    ]);
+    expect(actual).toBe('    312');
+  });
+
+  it('should respect multiple mending types', () => {
+    const fixedWidthParser = new FixedWidthParser([
+      {
+        name: 'Money',
+        start: 0,
+        width: 3,
+        type: 'int',
+        mend: 'round',
+        radix: 10,
+      },
+      {
+        name: 'Yuan',
+        start: 3,
+        width: 3,
+        type: 'int',
+        mend: 'floor',
+        radix: 10,
+      },
+      {
+        name: 'Won',
+        start: 6,
+        width: 3,
+        type: 'int',
+        mend: 'ceil',
+        radix: 10,
+      },
+    ]);
+    const actual = fixedWidthParser.unparse([
+      {
+        Money: 312.45,
+        Yuan: 313.67,
+        Won: 421.9,
+      },
+    ]);
+    expect(actual).toBe('312313422');
+  });
+
+  it('should throw an error when the mend type is error for an int', () => {
+    const fixedWidthParser = new FixedWidthParser([
+      {
+        name: 'Money',
+        start: 0,
+        width: 7,
+        type: 'int',
+        mend: 'error',
+      },
+    ]);
+    try {
+      fixedWidthParser.unparse([
+        {
+          Money: 312.45,
+        },
+      ]);
+    } catch (error) {
+      expect(error.message).toBeDefined();
+    }
   });
 });

--- a/test/unparse.spec.ts
+++ b/test/unparse.spec.ts
@@ -617,4 +617,34 @@ describe('FixedWidthParser.unparse', () => {
 
     expect(actual).toStrictEqual('a');
   });
+
+  it('should throw an error if an int value is not an int', () => {
+    const fixedWidthParser = new FixedWidthParser([
+      {
+        name: 'Age',
+        start: 0,
+        width: 7,
+        type: 'int',
+      },
+      {
+        name: 'Initial',
+        start: 7,
+        width: 4,
+      },
+    ]);
+    try {
+      fixedWidthParser.unparse([
+        {
+          Age: 3.10,
+          Initial: 'SJP',
+        },
+        {
+          Age: 20,
+          Initial: 'CCS',
+        },
+      ]);
+    } catch (error) {
+      expect(error.message).toBe("Int value was not an int")
+    }
+  });
 });


### PR DESCRIPTION
## Updates

- Give end-users an option to have their own mending style for `IIntegerParseConfig`.
- Options that given to the end-user are:
-- floor: floors the integer (returns the current int)
-- ceil: ceils the integer (returns the next int if a decimal is given above 0
-- round: rounds the integer to the closest integer
-- error: throw an error if anything but int is given. 
- Added test cases for these to support 100% code coverage 