### PR TITLE
Feature/date parse fallbacks

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,17 +6,13 @@ labels: ''
 assignees: ''
 ---
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+**Describe the bug** A clear and concise description of what the bug is.
 
-**To Reproduce**
-Steps to reproduce the behavior:
+**To Reproduce** Steps to reproduce the behavior:
 
-**Expected behavior**
-A clear and concise description of what you expected to happen.
+**Expected behavior** A clear and concise description of what you expected to happen.
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+**Screenshots** If applicable, add screenshots to help explain your problem.
 
 **Desktop (please complete the following information):**
 
@@ -24,5 +20,4 @@ If applicable, add screenshots to help explain your problem.
 - Node version [e.g. chrome, safari]
 - Package version [e.g. 22]
 
-**Additional context**
-Add any other context about the problem here.
+**Additional context** Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,14 +6,12 @@ labels: ''
 assignees: ''
 ---
 
-**Is your feature request related to a problem? Please describe.**
-A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+**Is your feature request related to a problem? Please describe.** A clear and concise description
+of what the problem is. Ex. I'm always frustrated when [...]
 
-**Describe the solution you'd like**
-A clear and concise description of what you want to happen.
+**Describe the solution you'd like** A clear and concise description of what you want to happen.
 
-**Describe alternatives you've considered**
-A clear and concise description of any alternative solutions or features you've considered.
+**Describe alternatives you've considered** A clear and concise description of any alternative
+solutions or features you've considered.
 
-**Additional context**
-Add any other context or screenshots about the feature request here.
+**Additional context** Add any other context or screenshots about the feature request here.

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,5 +1,6 @@
 {
   "singleQuote": true,
   "printWidth": 100,
-  "trailingComma": "all"
+  "trailingComma": "all",
+  "proseWrap": "always"
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Change log
 
+## 3.0.0
+
+- Add `date` parse `tryParsingRawValueBeforeFallback` option to attempt parsing the raw value as a
+  Date before failing after failing to parse the trimmed value as a Date
+- Enhance `date` parse `falsyFallback == 'passthrough'` behavior to pass through trimmed value
+
 ## 2.5.1
 
 - Updated `date-fns` dependency

--- a/README.md
+++ b/README.md
@@ -220,6 +220,7 @@ interface IDateParseConfig {
   // unicode date field symbol pattern
   jsonFormat: string;
   // attempt to parse raw value before failing if trimmed value is not parsable as a Date
+  // default: false
   tryParsingRawValueBeforeFallback: boolean;
 }
 ```

--- a/README.md
+++ b/README.md
@@ -219,6 +219,8 @@ interface IDateParseConfig {
   // required
   // unicode date field symbol pattern
   jsonFormat: string;
+  // attempt to parse raw value before failing if trimmed value is not parsable as a Date
+  tryParsingRawValueBeforeFallback: boolean;
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@
 ![NPM](https://img.shields.io/npm/l/fixed-width-parser)
 ![Snyk Vulnerabilities for npm package version](https://img.shields.io/snyk/vulnerabilities/npm/fixed-width-parser)
 
-`fixed-width-parser` is a node module for parsing data to and from fixed width string
-formats.
+`fixed-width-parser` is a node module for parsing data to and from fixed width string formats.
 
 ## Install
 
@@ -125,9 +124,9 @@ const result = fixedWidthParser.unparse(input);
 
 ## Config
 
-When initializing a new instance of the `FixedWidthParser` class, you must provide
-an array of parse configs. These configs define how to convert between lines of
-text and json objects by providing a mapping between segments of text and object keys.
+When initializing a new instance of the `FixedWidthParser` class, you must provide an array of parse
+configs. These configs define how to convert between lines of text and json objects by providing a
+mapping between segments of text and object keys.
 
 All parse configs share the following properties:
 
@@ -156,9 +155,9 @@ interface IBaseParseConfig {
 }
 ```
 
-An explicit `type` property can be provided in each parse config to specify what
-data types to use for values parsed from strings. Several of these data types require
-additional properties to be provided to fully define how parse/unparse values.
+An explicit `type` property can be provided in each parse config to specify what data types to use
+for values parsed from strings. Several of these data types require additional properties to be
+provided to fully define how parse/unparse values.
 
 ```typescript
 // Default config type
@@ -246,9 +245,9 @@ interface ISkipParseConfig {
 
 ### Parse Config Validation
 
-When constructing a new `FixedWidthParser` instance the provided parse config will
-be validated. If any errors are detected an array of validation errors will be thrown
-to help you find and correct the invalid configs.
+When constructing a new `FixedWidthParser` instance the provided parse config will be validated. If
+any errors are detected an array of validation errors will be thrown to help you find and correct
+the invalid configs.
 
 ```typescript
 interface IParseConfigValidationError {
@@ -307,8 +306,8 @@ interface IFixedWidthParserOptions {
 
 ## Parser Logger
 
-By default any logs from the parser will be handled by the built in `console` logger.
-You can optionally provide your own `ILogger` compatible logger to process logs.
+By default any logs from the parser will be handled by the built in `console` logger. You can
+optionally provide your own `ILogger` compatible logger to process logs.
 
 ```typescript
 const { FixedWidthParser, ILogger } = require('fixed-width-parser');
@@ -338,10 +337,8 @@ const fixedWidthParser = new FixedWidthParser(
 
 ## Thanks
 
-A huge thanks to @SteveyPugs for his work on `fixy` which served as inspiration
-for `fixed-width-parser`! `fixed-width-parser` started out as a fork of `fixy` and
-evolved into its own library when I got carried away and implemented a new high-level
-API.
+A huge thanks to @SteveyPugs for his work on `fixy` which served as inspiration for
+`fixed-width-parser`! `fixed-width-parser` started out as a fork of `fixy` and evolved into its own
+library when I got carried away and implemented a new high-level API.
 
-Another huge thanks to @wk-davis for her help with concept discussions and ongoing
-development help!
+Another huge thanks to @wk-davis for her help with concept discussions and ongoing development help!

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "fixed-width-parser",
-  "version": "2.5.1",
+  "version": "3.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "fixed-width-parser",
-      "version": "2.5.1",
+      "version": "3.0.0",
       "license": "MIT",
       "dependencies": {
         "date-fns": "^2.28.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fixed-width-parser",
-  "version": "2.5.1",
+  "version": "3.0.0",
   "description": "A fixed width data parser",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/FixedWidthParser.ts
+++ b/src/FixedWidthParser.ts
@@ -308,7 +308,19 @@ export class FixedWidthParser<T extends JsonObject = JsonObject> {
           return formatDate(parsedDate, config.jsonFormat);
         }
 
-        const failValue = handleFalsyFallback(null, config.falsyFallback ?? options.falsyFallback);
+        if (config.tryParsingRawValueBeforeFallback) {
+          const parsedRawDate = parseToDate(rawString, config.fixedWidthFormat, new Date());
+          if (isValidDate(parsedRawDate)) {
+            return formatDate(parsedRawDate, config.jsonFormat);
+          }
+        }
+
+        let failValue: string | number | false;
+        if (config.falsyFallback === 'passthrough') {
+          failValue = trimmedString;
+        } else {
+          failValue = handleFalsyFallback(null, config.falsyFallback ?? options.falsyFallback);
+        }
         this.logger.warn(`Failed to parse to date value. Falling back to ${failValue}.`);
         return failValue;
       }

--- a/src/interfaces/ParseConfig.ts
+++ b/src/interfaces/ParseConfig.ts
@@ -51,6 +51,7 @@ export interface IDateParseConfig extends IBaseParseConfig {
   name: string;
   fixedWidthFormat: string;
   jsonFormat: string;
+  tryParsingRawValueBeforeFallback: boolean;
 }
 
 export interface IBooleanParseConfig extends IBaseParseConfig {

--- a/test/parse.spec.ts
+++ b/test/parse.spec.ts
@@ -395,6 +395,36 @@ describe('FixedWidthParser.parse', () => {
     ]);
   });
 
+  it('should handle falsy fallback options', () => {
+    const fixedWidthParser = new FixedWidthParser([
+      {
+        type: 'date',
+        name: 'a',
+        width: 6,
+        start: 0,
+        padChar: '0',
+        falsyFallback: 'passthrough',
+        jsonFormat: 'HH:mm:ss',
+        fixedWidthFormat: 'HHmmss',
+        tryParsingRawValueBeforeFallback: true,
+      },
+    ]);
+
+    const actual = fixedWidthParser.parse('123000\n000bad\n030000');
+
+    expect(actual).toStrictEqual([
+      {
+        a: '12:30:00',
+      },
+      {
+        a: 'bad',
+      },
+      {
+        a: '03:00:00',
+      },
+    ]);
+  });
+
   it('should parse date segments with falsyFallback options', () => {
     const fixedWidthParser = new FixedWidthParser([
       {


### PR DESCRIPTION
## What :love_letter:

<!-- Please clearly describe what this PR changes, any expected impacts, and what you have done to test it -->

- Add `date` parse `tryParsingRawValueBeforeFallback` option to attempt parsing the raw value as a
  Date before failing after failing to parse the trimmed value as a Date
- Enhance `date` parse `falsyFallback == 'passthrough'` behavior to pass through trimmed value

## Checklist :santa:

- [x] Version has been bumped
- [x] Documentation has been updated
- [x] Changelog has been updated
